### PR TITLE
Add missing ImageChange trigger

### DIFF
--- a/openshift/app.dc.yaml
+++ b/openshift/app.dc.yaml
@@ -101,6 +101,15 @@ objects:
       test: false
       triggers:
         - type: ConfigChange
+        - imageChangeParams:
+            automatic: true
+            containerNames:
+            - "${APP_NAME}-app-${JOB_NAME}"
+            from:
+              kind: ImageStreamTag
+              name: "${REPO_NAME}-app:${JOB_NAME}"
+              namespace: "${NAMESPACE}"
+          type: ImageChange
   - apiVersion: v1
     kind: Service
     metadata:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
This should make it so that newer deployments actually trigger a new replicaset.
<!-- Why is this change required? What problem does it solve? -->
If this isn't applied, the deployment config will not update with a newer image.
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
