### PR TITLE
Removed enclosing array from JSON template data

### DIFF
--- a/app/frontend/src/components/FileInput.vue
+++ b/app/frontend/src/components/FileInput.vue
@@ -92,7 +92,7 @@
                     <v-textarea
                       auto-grow
                       hint="JSON format for key-value pairs"
-                      label="JSON data containing an array of contexts"
+                      label="The JSON object with key-value pairs"
                       mandatory
                       required
                       rows="3"
@@ -306,7 +306,7 @@ export default {
       Object.keys(this.form).forEach(key => {
         this.form[key] = null;
       });
-      this.form.contexts = '[{}]';
+      this.form.contexts = '{}';
       this.form.outputFileName = '';
       // clear json builder items
       if (this.$refs.jsonBuilder) this.$refs.jsonBuilder.reset();
@@ -348,7 +348,8 @@ export default {
     },
     updateContexts(obj) {
       try {
-        this.form.contexts = JSON.stringify(obj);
+        // create a JSON object of context(s)
+        this.form.contexts = Array.isArray(obj) ? JSON.stringify(obj[0]) : JSON.stringify(obj);
       } catch (e) {
         console.error(e, obj);
       }

--- a/app/frontend/src/components/FileInput.vue
+++ b/app/frontend/src/components/FileInput.vue
@@ -196,15 +196,9 @@ export default {
             return 'Must be an JSON object';
           }
         },
-        v => {
-          try {
-            if (Array.isArray(JSON.parse(v)).length) throw new Error();
-            return true;
-          } catch (e) {
-            return 'Array must have at least one element';
-          }
-        }
+        v => !Array.isArray(JSON.parse(v)) || 'Should not be an array'
       ],
+
       templateBuilderRules: [
         v =>
           !RegExp(/^.*?{(?!.*?})[^}]*$|^[^{\r\n]*}.*?$/).test(v) ||
@@ -349,7 +343,7 @@ export default {
     updateContexts(obj) {
       try {
         // create a JSON object of context(s)
-        this.form.contexts = Array.isArray(obj) ? JSON.stringify(obj[0]) : JSON.stringify(obj);
+        this.form.contexts = JSON.stringify(obj);
       } catch (e) {
         console.error(e, obj);
       }

--- a/app/frontend/src/components/JsonBuilder.vue
+++ b/app/frontend/src/components/JsonBuilder.vue
@@ -71,7 +71,7 @@ export default {
         (obj, item) => ((obj[item.key] = item.value), obj),
         {}
       );
-      this.$emit('json-object', [obj]);
+      this.$emit('json-object', obj);
     },
     reset() {
       this.items = [];

--- a/app/frontend/src/views/CDOGS.vue
+++ b/app/frontend/src/views/CDOGS.vue
@@ -2,7 +2,7 @@
   <v-container class="secure">
     <Authenticated>
       <h1 class="text-center">
-        Common Document Generation Service (v1)
+        Common Document Generation Service (v2)
         <Health />
       </h1>
       <p class="text-center">

--- a/app/src/cdogsService/cdogsService.js
+++ b/app/src/cdogsService/cdogsService.js
@@ -51,6 +51,11 @@ class CdogsService {
   }
 
   async docGen(body) {
+
+    // After change to CDOGS V2
+    // The JSON data (replacements) shouldn't be enclosed in an array
+    body.data = body.data[0];
+
     try {
       const endpoint = `${this.apiUrl}/template/render`;
       log.debug('docGen', `POST to ${endpoint}`);

--- a/app/src/cdogsService/cdogsService.js
+++ b/app/src/cdogsService/cdogsService.js
@@ -51,13 +51,6 @@ class CdogsService {
   }
 
   async docGen(body) {
-
-    // After change to CDOGS V2
-    // The JSON data (replacements) shouldn't be enclosed in an array
-    if(Array.isArray(body.data)) {
-      body.data = body.data[0];
-    }
-
     try {
       const endpoint = `${this.apiUrl}/template/render`;
       log.debug('docGen', `POST to ${endpoint}`);

--- a/app/src/cdogsService/cdogsService.js
+++ b/app/src/cdogsService/cdogsService.js
@@ -54,7 +54,9 @@ class CdogsService {
 
     // After change to CDOGS V2
     // The JSON data (replacements) shouldn't be enclosed in an array
-    body.data = body.data[0];
+    if(Array.isArray(body.data)) {
+      body.data = body.data[0];
+    }
 
     try {
       const endpoint = `${this.apiUrl}/template/render`;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

CDOGS v2 doesn't expect the template data enclosed in an array.
The DGRSC example files and code generated in the template data textarea still uses the enclosing array so I've stripped the array at the data service level.

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
