### PR TITLE
Warn user that DGRSC is for testing only

### DIFF
--- a/app/frontend/src/views/CDOGS.vue
+++ b/app/frontend/src/views/CDOGS.vue
@@ -1,5 +1,25 @@
 <template>
   <v-container class="secure">
+    <v-alert
+      class="mt-5 mb-5 pl-7 alert"
+      type="warning"
+      icon="mdi-alert"
+      border="left"
+      color="#d9a300"
+      colored-border
+      outlined
+      dismissible
+    >
+      <p class="text-h6 mb-2">This website is to be used only for test purposes</p>
+      <p class="mb-1">
+        This is a demonstration tool meant to be used with test data.
+        Do not use it to create documents with sensitive information.
+      </p>
+      <p class="mb-1">
+        For that, you will call the CDOGS API from within your own application (using your own service account) and
+        complete a <strong>Privacy Impact Assessment (PIA)</strong> and <strong>Threat and Risk Assessment (STRA)</strong>.
+      </p>
+    </v-alert>
     <Authenticated>
       <h1 class="text-center">
         Common Document Generation Service (v2)
@@ -34,3 +54,12 @@ export default {
   }
 };
 </script>
+
+<!-- Vuetify uses !important internally, so we have to override ALL of them same way -->
+<style lang="scss" scoped>
+.alert {
+  color: #6c4a00 !important;
+  border-color: #faebcc !important;
+  background-color: #f9f1c6 !important;
+}
+</style>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
<!-- Describe your changes in detail -->
This adds a warning at the top of the CDOGS page, warning the user that DGRSC is only for testing purposes and that a PIA/STRA is needed for actual use, along with being granted access via service account to the CDOGS API.

![Screenshot 2024-04-09 at 9 42 56 AM](https://github.com/bcgov/document-generation-showcase/assets/103449568/2fcb6d23-1107-4aa6-a83e-1d269df1aae3)

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
Documentation (non-breaking change with enhancements to documentation)
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
N/A
